### PR TITLE
Print CompileGlobalScript timing info to stdout, not to stderr

### DIFF
--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -622,7 +622,7 @@ struct AutoTimer
     ~AutoTimer() {
         timespec end;
         clock_gettime(CLOCK_MONOTONIC, &end);
-        fprintf(stdout, "%s took %ld ns\n", name, elapsedNs(&start, &end));
+        fprintf(stderr, "%s took %ld ns\n", name, elapsedNs(&start, &end));
     }
 };
 


### PR DESCRIPTION
jstests scrapes stdout, so printing there breaks stuff.
