### PR TITLE
Update various Reflect.parse tests for the permissibility of `for (const ... of ...)`

### DIFF
--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -622,7 +622,7 @@ struct AutoTimer
     ~AutoTimer() {
         timespec end;
         clock_gettime(CLOCK_MONOTONIC, &end);
-        fprintf(stdout, "%s took %ld ns\n", name, elapsedNs(&start, &end));
+        fprintf(stderr, "%s took %ld ns\n", name, elapsedNs(&start, &end));
     }
 };
 

--- a/js/src/tests/js1_8_5/reflect-parse/for-loop-destructuring.js
+++ b/js/src/tests/js1_8_5/reflect-parse/for-loop-destructuring.js
@@ -34,9 +34,12 @@ assertStmt("for (const {a:x,b:y,c:z} in foo);",
 assertStmt("for (const [x,y,z] in foo);",
            forInStmt(constDecl([{ id: xyz, init: null }]), ident("foo"), emptyStmt));
 
-assertError("for (const x of foo);", SyntaxError);
-assertError("for (const {a:x,b:y,c:z} of foo);", SyntaxError);
-assertError("for (const [x,y,z] of foo);", SyntaxError);
+assertStmt("for (const x of foo);",
+           forOfStmt(constDecl([{id: ident("x"), init: null }]), ident("foo"), emptyStmt));
+assertStmt("for (const {a:x,b:y,c:z} of foo);",
+           forOfStmt(constDecl([{ id: axbycz, init: null }]), ident("foo"), emptyStmt));
+assertStmt("for (const [x,y,z] of foo);",
+           forOfStmt(constDecl([{ id: xyz, init: null }]), ident("foo"), emptyStmt));
 
 assertStmt("for each (const x in foo);",
            forEachInStmt(constDecl([{ id: ident("x"), init: null }]), ident("foo"), emptyStmt));


### PR DESCRIPTION
Really just the last of these revs, the other is in the previous PR, but I can't do any jstest testing without that other, so it's going to be in these separate PRs until it lands.
