### PR TITLE
Implement `[[VarNames]]` handling and rejection of lexical declarations that would encroach on names in that list

### DIFF
--- a/js/public/GCHashTable.h
+++ b/js/public/GCHashTable.h
@@ -237,7 +237,7 @@ namespace JS {
 
 // A GCHashSet is a HashSet with an additional trace method that knows
 // be traced to be kept alive will generally want to use this GCHashSet
-// specializeation in lieu of HashSet.
+// specialization in lieu of HashSet.
 //
 // Most types of GC pointers can be traced with no extra infrastructure. For
 // structs and non-gc-pointer members, ensure that there is a specialization of

--- a/js/public/MemoryMetrics.h
+++ b/js/public/MemoryMetrics.h
@@ -710,6 +710,7 @@ struct CompartmentStats
     macro(Other,   MallocHeap, crossCompartmentWrappersTable) \
     macro(Other,   MallocHeap, regexpCompartment) \
     macro(Other,   MallocHeap, savedStacksSet) \
+    macro(Other,   MallocHeap, varNamesSet) \
     macro(Other,   MallocHeap, nonSyntacticLexicalScopesTable) \
     macro(Other,   MallocHeap, jitCompartment) \
     macro(Other,   MallocHeap, privateData)

--- a/js/src/tests/ecma_6/LexicalEnvironment/redeclaring-global-properties.js
+++ b/js/src/tests/ecma_6/LexicalEnvironment/redeclaring-global-properties.js
@@ -1,0 +1,41 @@
+// |reftest| skip-if(!xulRuntime.shell) -- needs evaluate
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/licenses/publicdomain/
+
+// Attempting to lexically redefine a var is a syntax error.
+evaluate("var a;");
+assertThrowsInstanceOf(() => evaluate("let a;"), SyntaxError);
+
+// Attempting to lexically redefine a global property that's not a var is okay.
+this.b = 42;
+assertEq(b, 42);
+evaluate("let b = 17;");
+assertEq(b, 17);
+
+// Attempting to lexically redefine a global property that wasn't a var
+// initially but was later declared as one, isn't okay.
+this.c = 8675309;
+assertEq(c, 8675309);
+evaluate("var c;");
+assertThrowsInstanceOf(() => evaluate("let c;"), SyntaxError);
+
+// Attempting to lexically redefine a var added by eval code isn't okay.
+assertEq(typeof d, "undefined");
+eval("var d = 33;");
+assertEq(d, 33);
+assertThrowsInstanceOf(() => evaluate("let d;"), SyntaxError);
+
+// Attempting to lexically redefine a var added by eval code, *then deleted*,
+// isn't okay.  (The |var| will add the name to the global environment record's
+// [[VarNames]], and it's not removed when the property is deleted.  #loljs)
+assertEq(typeof e, "undefined");
+eval("var e = 'ohia';");
+assertEq(e, "ohia");
+delete this.e;
+assertEq(this.hasOwnProperty("e"), false);
+assertThrowsInstanceOf(() => evaluate("let e;"), SyntaxError);
+
+if (typeof reportCompare === "function")
+  reportCompare(true, true);
+
+print("Tests complete");

--- a/js/src/vm/Interpreter-inl.h
+++ b/js/src/vm/Interpreter-inl.h
@@ -374,6 +374,11 @@ DefVarOperation(JSContext* cx, HandleObject varobj, HandlePropertyName dn, unsig
             return false;
     }
 
+    if (varobj->is<GlobalObject>()) {
+        if (!varobj->compartment()->addToVarNames(cx, dn))
+            return false;
+    }
+
     return true;
 }
 

--- a/js/src/vm/MemoryMetrics.cpp
+++ b/js/src/vm/MemoryMetrics.cpp
@@ -351,6 +351,7 @@ StatsCompartmentCallback(JSRuntime* rt, void* data, JSCompartment* compartment)
                                         &cStats.crossCompartmentWrappersTable,
                                         &cStats.regexpCompartment,
                                         &cStats.savedStacksSet,
+                                        &cStats.varNamesSet,
                                         &cStats.nonSyntacticLexicalScopesTable,
                                         &cStats.jitCompartment,
                                         &cStats.privateData);


### PR DESCRIPTION
Note that it _does_ have to be a list, and it can't be a flag on the shape or somesuch.  See the `eval` bit in the testcase.  Woo JS!

I think this is a semantic improvement versus our behavior in mozilla-inbound.  I happened to notice and desire to fix it, tho, because at some point -- you squashed history so I don't (think I can) know when :-( -- CheckLexicalNameConflict's `varObj->isNative() && (shape = varObj->as<NativeObject>().lookup(cx, name))` arm went from containing `if (!shape->configurable()) redeclKind = Some(Var);` to just containing the assignment without the guard.  I assume this "fixed" some jit-test.  But it had the cost of breaking a jstest, namely js1_7/regress/regress-407727-01.js.
