### PR TITLE
Don't test for syntax error when 2**20 blocks are in a script

### DIFF
--- a/js/src/tests/js1_8_5/regress/regress-610026.js
+++ b/js/src/tests/js1_8_5/regress/regress-610026.js
@@ -7,10 +7,9 @@
 var expect = "pass";
 var actual;
 
-/*
- * We hardcode here that a program is limited to 2^20 blocks. Start
- * with 2^19 blocks, then test 2^20 - 1 blocks, finally test the limit.
- */
+// Scripts used to be limited to 2**20 blocks, but no longer since the frontend
+// rewrite.  The exact limit-testing here should all pass now, not pass for
+// 2**20 - 1 and fail for 2**20.
 var s = "{}";
 for (var i = 0; i < 21; i++)
     s += s;
@@ -39,9 +38,9 @@ s += "{}";
 
 try {
     eval(s);
-    actual = "fail: expected InternalError: program too large";
+    actual = "pass";
 } catch (e) {
-    actual = (e.message == "program too large") ? "pass" : "fail: " + e;
+    actual = "fail: " + e;
 }
 
 assertEq(actual, expect);


### PR DESCRIPTION
If memory serves, this was handled by pn_blockid and some constant somewhere, but I don't get any hits in the frontend for `blockid` any more, so this limit looks dead.  Good riddance, it always looked stupid.
