### PR TITLE
BytecodeEmitter::needsImplicitThis() should check for `with` across function scope boundaries

### DIFF
--- a/js/src/frontend/BytecodeEmitter.cpp
+++ b/js/src/frontend/BytecodeEmitter.cpp
@@ -410,6 +410,8 @@ class BytecodeEmitter::EmitterScope : public Nestable<BytecodeEmitter::EmitterSc
         return Nothing();
     }
 
+    friend bool BytecodeEmitter::needsImplicitThis();
+
     EmitterScope* enclosing(BytecodeEmitter** bce) const {
         // There is an enclosing scope with access to the same frame.
         if (enclosingInFrame())
@@ -2533,8 +2535,9 @@ BytecodeEmitter::needsImplicitThis()
         return true;
 
     // Otherwise see if the current point is under a 'with'.
-    for (EmitterScope* es = innermostEmitterScope; es; es = es->enclosingInFrame()) {
-        if (es->scope(this)->kind() == ScopeKind::With)
+    BytecodeEmitter* bce = this;
+    for (EmitterScope* es = innermostEmitterScope; es; es = es->enclosing(&bce)) {
+        if (es->scope(bce)->kind() == ScopeKind::With)
             return true;
     }
 

--- a/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
+++ b/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
@@ -6,7 +6,7 @@
 var BUGNUMBER = 671947;
 var summary = "Unqualified function invocation uses the global object of the called property as |this|";
 var actual = "------------------------";
-var expect = "ooaoboab";
+var expect = "";
 
 print(BUGNUMBER + ": " + summary);
 
@@ -72,18 +72,18 @@ assertEq(sb.evaluate('(function(){with(b){ return (1,g)(); }})();'), "u");
 assertEq(sb.evaluate('(function(){with(b){ return a.g(); }})();'), "a");
 assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("g()");})(); }})();'), "b");
 
+/* Same as the first set, but h is a getter property. */
+assertEq(sb.evaluate('(function(){return h();})();'), "o");
+assertEq(sb.evaluate('(function(){return (1,h)();})();'), "o");
+assertEq(sb.evaluate('(function(){return a.h();})();'), "a");
+assertEq(sb.evaluate('(function(){return eval("h()");})();'), "o");
+assertEq(sb.evaluate('(function(){with(b){ return h(); }})();'), "b");
+assertEq(sb.evaluate('(function(){with(b){ return (1,h)(); }})();'), "o");
+assertEq(sb.evaluate('(function(){with(b){ return a.h(); }})();'), "a");
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("h()");})(); }})();'), "b");
+
 sb.evaluate(
        'var results = "";\n' +
-
-       ' /* Same as the first set, but h is a getter property. */\n' +
-       ' results += (function(){return h();})();\n' +
-       ' results += (function(){return (1,h)();})();\n' +
-       ' results += (function(){return a.h();})();\n' +
-       ' results += (function(){return eval("h()");})();\n' +
-       ' results += (function(){with(b){ return h(); }})();\n' +
-       ' results += (function(){with(b){ return (1,h)(); }})();\n' +
-       ' results += (function(){with(b){ return a.h(); }})();\n' +
-       ' results += (function(){with(b){ return (function(){ return eval("h()");})(); }})();\n' +
 
        ' parent.actual = results;\n' +
        '');

--- a/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
+++ b/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
@@ -6,7 +6,7 @@
 var BUGNUMBER = 671947;
 var summary = "Unqualified function invocation uses the global object of the called property as |this|";
 var actual = "------------------------";
-var expect = "uuaubuabooaoboab";
+var expect = "ooaoboab";
 
 print(BUGNUMBER + ": " + summary);
 
@@ -61,19 +61,19 @@ assertEq(sb.evaluate('(function(){with(b){ return (function(){ return (1,f)();})
 assertEq(sb.evaluate('(function(){with(b){ return (function(){ return a.f();})(); }})();'), "a");
 assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("f()");})(); }})();'), "b");
 
+// Same tests as above, but with a strict callee.  We expect the same results,
+// except undefined this is not replaced with the global object.
+assertEq(sb.evaluate('(function(){return g();})();'), "u");
+assertEq(sb.evaluate('(function(){return (1,g)();})();'), "u");
+assertEq(sb.evaluate('(function(){return a.g();})();'), "a");
+assertEq(sb.evaluate('(function(){return eval("g()");})();'), "u");
+assertEq(sb.evaluate('(function(){with(b){ return g(); }})();'), "b");
+assertEq(sb.evaluate('(function(){with(b){ return (1,g)(); }})();'), "u");
+assertEq(sb.evaluate('(function(){with(b){ return a.g(); }})();'), "a");
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("g()");})(); }})();'), "b");
+
 sb.evaluate(
        'var results = "";\n' +
-
-       ' /* Same tests as above, but with a strict callee. */\n' +
-       ' /* We expect the same results, except undefined this is not replaced with the global object. */\n' +
-       ' results += (function(){return g();})();\n' +
-       ' results += (function(){return (1,g)();})();\n' +
-       ' results += (function(){return a.g();})();\n' +
-       ' results += (function(){return eval("g()");})();\n' +
-       ' results += (function(){with(b){ return g(); }})();\n' +
-       ' results += (function(){with(b){ return (1,g)(); }})();\n' +
-       ' results += (function(){with(b){ return a.g(); }})();\n' +
-       ' results += (function(){with(b){ return (function(){ return eval("g()");})(); }})();\n' +
 
        ' /* Same as the first set, but h is a getter property. */\n' +
        ' results += (function(){return h();})();\n' +

--- a/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
+++ b/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
@@ -6,7 +6,7 @@
 var BUGNUMBER = 671947;
 var summary = "Unqualified function invocation uses the global object of the called property as |this|";
 var actual = "------------------------";
-var expect = "boabuuaubuabooaoboab";
+var expect = "uuaubuabooaoboab";
 
 print(BUGNUMBER + ": " + summary);
 
@@ -51,18 +51,18 @@ assertEq(sb.evaluate('(function(){return (1,f)();})();'), "o");
 assertEq(sb.evaluate('(function(){return a.f();})();'), "a");
 assertEq(sb.evaluate('(function(){return eval("f()");})();'), "o");
 
+// Same cases as above, but wrapped in a with. The first and last of these cases
+// pass b, the object scoped by the with, as the this value.  a.f() still passes
+// the explicit base, a. (1,f)() is a little tricksier - this passes undefined
+// (promoted to the callee global object) since the comma operator calls
+// GetValue on the reference (see ES5 11.14.).
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return f();})(); }})();'), "b");
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return (1,f)();})(); }})();'), "o");
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return a.f();})(); }})();'), "a");
+assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("f()");})(); }})();'), "b");
+
 sb.evaluate(
        'var results = "";\n' +
-
-       ' /* Same cases as above, but wrapped in a with. The first & last of these cases pass b, */\n' +
-       ' /* the object scoped by the with, as the this value. */\n' +
-       ' /* a.f() still passes the explicit base, a. (1,f)() is a little tricksier - this passes */\n' +
-       ' /* undefined (promoted to the callee global object) since the comma operator calles GetValue */\n' +
-       ' /* on the reference (see ES5 11.14.) */\n' +
-       ' results += (function(){with(b){ return (function(){ return f();})(); }})();\n' +
-       ' results += (function(){with(b){ return (function(){ return (1,f)();})(); }})();\n' +
-       ' results += (function(){with(b){ return (function(){ return a.f();})(); }})();\n' +
-       ' results += (function(){with(b){ return (function(){ return eval("f()");})(); }})();\n' +
 
        ' /* Same tests as above, but with a strict callee. */\n' +
        ' /* We expect the same results, except undefined this is not replaced with the global object. */\n' +

--- a/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
+++ b/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
@@ -5,8 +5,6 @@
 //-----------------------------------------------------------------------------
 var BUGNUMBER = 671947;
 var summary = "Unqualified function invocation uses the global object of the called property as |this|";
-var actual = "------------------------";
-var expect = "";
 
 print(BUGNUMBER + ": " + summary);
 
@@ -82,10 +80,5 @@ assertEq(sb.evaluate('(function(){with(b){ return (1,h)(); }})();'), "o");
 assertEq(sb.evaluate('(function(){with(b){ return a.h(); }})();'), "a");
 assertEq(sb.evaluate('(function(){with(b){ return (function(){ return eval("h()");})(); }})();'), "b");
 
-sb.evaluate(
-       'var results = "";\n' +
-
-       ' parent.actual = results;\n' +
-       '');
-
-reportCompare(expect, actual, "ok");
+if (typeof reportCompare === "function");
+  reportCompare(true, true);

--- a/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
+++ b/js/src/tests/ecma_5/Global/cross-global-implicit-this.js
@@ -1,4 +1,4 @@
-// |reftest| skip-if(!xulRuntime.shell)
+// |reftest| skip-if(!xulRuntime.shell) -- needs evaluate()
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/licenses/publicdomain/
 
@@ -27,10 +27,11 @@ function h() {
   return this ? this.name : "v";
 }
 
-var sb = newGlobal('same-compartment');
+var sb = newGlobal();
 sb.parent = this;
 
-evalcx('\n' +
+sb.evaluate(
+       '\n' +
        ' this.name="i";\n' +
        ' this.f = parent.f;\n' +
        ' this.g = parent.g;\n' +
@@ -80,7 +81,6 @@ evalcx('\n' +
        ' results += (function(){with(b){ return (function(){ return eval("h()");})(); }})();\n' +
 
        ' parent.actual = results;\n' +
-       '',
-       sb);
+       '');
 
 reportCompare(expect, actual, "ok");


### PR DESCRIPTION
It's entirely possible it'd be better to make the loop there a method in `EmitterScope`.  I did it this way because it was simplest, and because adding a single friendship relationship was the smallest way to fix.  Whether it's cleanest, I leave in your capable hands.

This actually fixes ecma_5/Global/cross-global-implicit-this.js.
