### PR TITLE
Expand an assertion to contemplate strict named lambdas in addition to regular old named lambdas

### DIFF
--- a/js/src/vm/EnvironmentObject.cpp
+++ b/js/src/vm/EnvironmentObject.cpp
@@ -1138,7 +1138,8 @@ EnvironmentIter::settle()
                 &env_->as<LexicalEnvironmentObject>().scope() == si_.scope())
             {
                 MOZ_ASSERT(si_.kind() == ScopeKind::ParameterDefaults ||
-                           si_.kind() == ScopeKind::NamedLambda);
+                           si_.kind() == ScopeKind::NamedLambda ||
+                           si_.kind() == ScopeKind::StrictNamedLambda);
                 env_ = &env_->as<EnvironmentObject>().enclosingEnvironment();
             }
             incrementScopeIter();


### PR DESCRIPTION
This assertion doesn't seem to need to treat named lambdas of differing strictness differently -- just an assert botch, looks like.

This fixes `test262/ch10/10.5/10.5-1-s.js`.
