### PR TITLE
Update ParseNode::generatorExpr() to account for the new internal structure of the generated PNK_FUNCTION for generator comprehensions

### DIFF
--- a/js/src/frontend/ParseNode.h
+++ b/js/src/frontend/ParseNode.h
@@ -693,8 +693,14 @@ class ParseNode
 
     ParseNode* generatorExpr() const {
         MOZ_ASSERT(isKind(PNK_GENEXP));
+
         ParseNode* callee = this->pn_head;
-        ParseNode* body = callee->pn_body;
+        MOZ_ASSERT(callee->isKind(PNK_FUNCTION));
+
+        ParseNode* paramsBody = callee->pn_body;
+        MOZ_ASSERT(paramsBody->isKind(PNK_PARAMSBODY));
+
+        ParseNode* body = paramsBody->last();
         MOZ_ASSERT(body->isKind(PNK_STATEMENTLIST));
         MOZ_ASSERT(body->last()->isKind(PNK_LEXICALSCOPE) ||
                    body->last()->isKind(PNK_COMPREHENSIONFOR));


### PR DESCRIPTION
The current assumption is PNK_GENEXP contains a function whose body is a PNK_STATEMENTLIST, but there now seems to be a PNK_PARAMSBODY as body now, whose last list element is the generator expr.  Refer to the new thing instead of the old thing.

This doesn't break any reflect-parse jstests, and it fixes the one, but I haven't run the full suite to be sure this doesn't break anything.  But the Parser code creating this stuff looks like it only creates the structure this patch implements, so I'm optimistic.
