### PR TITLE
Fix compiler warnings in rebased frontend-rewrite branch

### DIFF
--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -6,6 +6,8 @@
 
 #include "frontend/BytecodeCompiler.h"
 
+#include "mozilla/IntegerPrintfMacros.h"
+
 #include "jscntxt.h"
 #include "jsscript.h"
 
@@ -625,7 +627,7 @@ struct AutoTimer
 
     ~AutoTimer() {
         int64_t elapsed = (mozilla::TimeStamp::Now() - start).ToMicroseconds() * 1000.0;
-        fprintf(stdout, "%s took %lld ns\n", name, elapsed);
+        fprintf(stdout, "%s took %" PRId64 " ns\n", name, elapsed);
     }
 };
 

--- a/js/src/frontend/Parser.cpp
+++ b/js/src/frontend/Parser.cpp
@@ -4082,7 +4082,7 @@ Parser<ParseHandler>::initializerInNameDeclaration(Node decl, Node binding,
 
             *forHeadKind = PNK_FORHEAD;
         } else {
-            MOZ_ASSERT(*forHeadKind = PNK_FORHEAD);
+            MOZ_ASSERT(*forHeadKind == PNK_FORHEAD);
         }
 
         // Per Parser::forHeadStart, the semicolon in |for (;| is ultimately


### PR DESCRIPTION
New-enough clang picks these up.

The one's a trivial format-string mismatch.

The other is more interesting.  Modern clang will warn if you have a side-effectful operation in an unevaluated context.  `MOZ_ASSERT` includes a static assertion with a `decltype` (an unevaluated context) that the type of the condition isn't one of a few botched types -- functions (always truthy) and a couple others.

Thus `*forHeadKind = PNK_FORHEAD` as assertion condition triggers the compiler warning.  It's not a bug in release builds, because the absence of this undesired assignment shouldn't matter.  It would sort of be a bug in debug builds, tho, in that the assertion wouldn't be doing its job (and indeed might actively cover up a problem if someone examined an actually-changed `*forHeadKind` after that point).
